### PR TITLE
Work with Rails.root, used as example in the README

### DIFF
--- a/lib/rack/maintenance.rb
+++ b/lib/rack/maintenance.rb
@@ -23,7 +23,7 @@ class Rack::Maintenance
 private ######################################################################
 
   def content_type
-    file.end_with?('json') ? 'application/json' : 'text/html'
+    file.to_s.end_with?('json') ? 'application/json' : 'text/html'
   end
 
   def environment

--- a/spec/rack-maintenance_spec.rb
+++ b/spec/rack-maintenance_spec.rb
@@ -78,6 +78,11 @@ describe "RackMaintenance with json maintenance file" do
     let(:file_name) { "spec/maintenance.json" }
     let(:content_type) { "application/json" }
   end
+
+  it_behaves_like "RackMaintenance" do
+    let(:file_name) { Pathname.new("spec/maintenance.json") }
+    let(:content_type) { "application/json" }
+  end
 end
 
 describe "RackMaintenance with html maintenance file" do


### PR DESCRIPTION
The example provided on the README uses `Rails.root.join('public', 'maintenance.html')` as a value for the `:file` parameter. Unfortunately this doesn't actually work. This is because that value is a Pathname instead of a String, and the former doesn't implement `#end_with?`, which is used in the code.
