### PR TITLE
Support post-processing of maintenance page

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -30,6 +30,14 @@ and then run `bundle`.
    :file => Rails.root.join('public', 'maintenance.json'),
    :env  => 'MAINTENANCE'
 
+ # You may provide an object that responds to call to provide
+ # post-processing of the maintenance page such as merging
+ # ENV values into the page through ERB
+ config.middleware.use 'Rack::Maintenance',
+   :file => Rails.root.join('public', 'maintenance.html.erb'),
+   :env  => 'MAINTENANCE',
+   :processor => lambda { |content| ERB.new(content).result }
+
 If <tt>:env</tt> is specified, all requests will be shown the
 maintenance page if the environment variable is set.
 

--- a/lib/rack/maintenance.rb
+++ b/lib/rack/maintenance.rb
@@ -13,7 +13,8 @@ class Rack::Maintenance
 
   def call(env)
     if maintenance? && path_in_app(env)
-      data = File.read(file)
+      content = File.read(file)
+      data = processor.call(content)
       [ 503, { 'Content-Type' => content_type, 'Content-Length' => data.bytesize.to_s }, [data] ]
     else
       app.call(env)
@@ -32,6 +33,10 @@ private ######################################################################
 
   def file
     options[:file]
+  end
+
+  def processor
+    options[:processor] || lambda { |content| content }
   end
 
   def maintenance?

--- a/spec/rack-maintenance_spec.rb
+++ b/spec/rack-maintenance_spec.rb
@@ -66,6 +66,18 @@ shared_examples "RackMaintenance" do
           app.should_not_receive :call
           rack.call({})
         end
+
+        context "and :processor option" do
+          let(:processor) { lambda { |content| ERB.new(content).result } }
+          let(:rack) do
+            Rack::Maintenance.new(app, :file => file_name, :processor => processor )
+          end
+
+          it "passes the file content to the processor" do
+            processor.should_receive(:call).with(data).and_call_original
+            rack.call({})
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This PR provides support for a :processor option.  The processor is any object responding to #call.  The processor will be passed the contents of the :file option so that it may perform any post-processing required before rendering the maintenance page to the requester.

As an example, consider maintenance.html.erb

    <!DOCTYPE html>
    <html>
      <body>
        <head>
          <h1>Site unavailable due to maintenace</h1>
        </head>
        <%- unless ENV['MAINTENANCE'] == "" %>
        <p><%= ENV["MAINTENANCE"] %></p>
        <% end %>
      </body>
    </html>

With an ERB template like that, the value of ENV["MAINTENANCE"] could be used to specify the reason for the maintenance, expected duration, etc.

    ENV["MAINTENANCE"] = "We are experiencing a disruption in Amazon S3 services."

Note: Explanatory text has been added to the README but version has not been bumped.