### PR TITLE
Support Allowed Paths from Environment Variable

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -50,6 +50,17 @@ If <tt>:env</tt> is not specified, the maintenance page will be shown if it exis
    :file => Rails.root.join('public', 'maintenance.html'),
    :without => /\A\/assets/
 
+ # Define the paths to enable while site is down by environment variable.
+ # If :without_env is specified, the paths to enable will be pulled from the
+ # value of that environment variable.
+ #
+ # This allows you to use :without as a default, and :without_env will override
+ # it if it's available.
+ config.middleware.use 'Rack::Maintenance',
+   :file => Rails.root.join('public', 'maintenance.html'),
+   :without => /\A\/assets/
+   :without_env => 'MAINTENANCE_ALLOWED_PATHS'
+
 == Note on Patches/Pull Requests
 
 * Fork the project.

--- a/lib/rack/maintenance.rb
+++ b/lib/rack/maintenance.rb
@@ -44,7 +44,20 @@ private ######################################################################
   end
 
   def path_in_app(env)
-    env["PATH_INFO"] !~ options[:without]
+    env["PATH_INFO"] !~ without
   end
 
+  def without
+    if configurable_allowlist
+      Regexp.new(configurable_allowlist)
+    else
+      options[:without]
+    end
+  end
+
+  def configurable_allowlist
+    if options[:without_env]
+      ENV[options[:without_env]]
+    end
+  end
 end


### PR DESCRIPTION
This extends the functionality that's introduced with the `:without`
option so that these paths can be defined via a regex that's placed in
an environment variable.

If both `:without` and `:without_env` are defined, then the value in the
environment variable will take precedence. This allows for you to define
a default set of allowed paths in the `:without` value, while also
allowing for the paths to be changed during a maintenance activity
without needing a code change with the environment variable defined in
`:without_env`.

If this is not functionality you'd like to support, and/or if you're not actively maintaining this middleware, I completely understand. Thanks for the consideration.